### PR TITLE
Naming for multiple EVPPI calculations

### DIFF
--- a/R/evppi.R
+++ b/R/evppi.R
@@ -236,6 +236,8 @@ evppi <- function(outputs,
 {
     inputs <- check_inputs(inputs, iname=deparse(substitute(inputs)))
     outputs <- check_outputs(outputs, inputs)
+    wtp <- outputs$k
+    nwtp <- length(wtp)
 
     if (!is.list(pars))
         pars <- list(pars)
@@ -266,7 +268,7 @@ evppi <- function(outputs,
                               ...)
     }
     res <- do.call("rbind", eres)
-    res <- cbind(pars=names(pars), res)
+    res <- cbind(pars=rep(names(pars), each = nwtp), res)
     if (check){
         attr(res, "models") <- lapply(eres, function(x)attr(x, "models"))
         names(attr(res, "models")) <- res$pars


### PR DESCRIPTION
Previous version incorrectly assigned the parameter names when computing multiple EVPPI values.